### PR TITLE
[macOS] Adjust padding of List items on sidebar

### DIFF
--- a/Reddit-macOS/Views/PostList.swift
+++ b/Reddit-macOS/Views/PostList.swift
@@ -25,7 +25,9 @@ struct PostList: View {
                     ForEach(listing != nil ? listing!.data.children.map { $0.data } : []) { post in
                         NavigationLink(destination: PostDetailView(post: post)) {
                             PostView(post: post)
-                                .tag(post.id)
+                            .tag(post.id)
+                            .padding(EdgeInsets(top: 5, leading: 0, bottom: 5, trailing: 0))
+
                             /// Double-click to open a new window for the `PostDetailView`
                             .onTapGesture(count: 2) {
                                 let controller = DetailWindowController(rootView: PostDetailView(post: post))

--- a/Reddit-macOS/Views/PostList.swift
+++ b/Reddit-macOS/Views/PostList.swift
@@ -27,7 +27,6 @@ struct PostList: View {
                             PostView(post: post)
                             .tag(post.id)
                             .padding(EdgeInsets(top: 5, leading: 0, bottom: 5, trailing: 0))
-
                             /// Double-click to open a new window for the `PostDetailView`
                             .onTapGesture(count: 2) {
                                 let controller = DetailWindowController(rootView: PostDetailView(post: post))


### PR DESCRIPTION
When clicking on an item in the sidebar, the padding of the selected state was 0 on top and bottom. This adjusts that padding to give a bit more breathing room to the content in the list!