### PR TITLE
When post author = comment author, set comment author color

### DIFF
--- a/Shared/Views/CommentsView.swift
+++ b/Shared/Views/CommentsView.swift
@@ -47,7 +47,7 @@ struct CommentView: View {
 
     var authorText: some View {
         if comment.author == postAuthor {
-            return Text(comment.author).foregroundColor(.accentColor)
+            return Text(comment.author).foregroundColor(.accentColor).bold()
         } else {
             return Text(comment.author)
         }

--- a/Shared/Views/CommentsView.swift
+++ b/Shared/Views/CommentsView.swift
@@ -44,6 +44,14 @@ struct CommentView: View {
     let comment: Comment
     let postAuthor: String
     let nestLevel: Int
+
+    var authorText: some View {
+        if comment.author == postAuthor {
+            return Text(comment.author).foregroundColor(.accentColor)
+        } else {
+            return Text(comment.author)
+        }
+    }
     
     var body: some View {
         Group {
@@ -57,12 +65,7 @@ struct CommentView: View {
                 /// Content
                 VStack(alignment: .leading) {
                     HStack {
-                        if comment.author == postAuthor {
-                            Text(comment.author)
-                                .foregroundColor(.accentColor)
-                        } else {
-                            Text(comment.author)
-                        }
+                        authorText
                         Image(systemName: "arrow.up")
                         Text("\(comment.score)")
                     }

--- a/Shared/Views/CommentsView.swift
+++ b/Shared/Views/CommentsView.swift
@@ -27,7 +27,7 @@ struct CommentsView: View {
                 // `dropFirst` because `first` is the actual post
                 if listings!.dropFirst().map({ $0.data.children }).flatMap({ $0.map { $0.data } }).count > 0 {
                     ForEach(listings!.dropFirst().map({ $0.data.children }).flatMap { $0.map { $0.data } }, id: \.id) { comment in
-                        CommentView(comment: comment, nestLevel: 0)
+                        CommentView(comment: comment, postAuthor: self.post.author, nestLevel: 0)
                     }
                 } else {
                     self.noComments
@@ -42,6 +42,7 @@ struct CommentsView: View {
 
 struct CommentView: View {
     let comment: Comment
+    let postAuthor: String
     let nestLevel: Int
     
     var body: some View {
@@ -56,12 +57,17 @@ struct CommentView: View {
                 /// Content
                 VStack(alignment: .leading) {
                     HStack {
-                        Text(comment.author)
+                        if comment.author == postAuthor {
+                            Text(comment.author)
+                                .foregroundColor(.accentColor)
+                        } else {
+                            Text(comment.author)
+                        }
                         Image(systemName: "arrow.up")
                         Text("\(comment.score)")
                     }
-                    .font(.caption)
-                    .opacity(0.75)
+                        .font(.caption)
+                        .opacity(0.75)
                     Text(comment.body ?? "")
                 }
             }
@@ -70,7 +76,7 @@ struct CommentView: View {
             /// Recursive comments
             if comment.replies != nil {
                 ForEach(comment.replies!.data.children.map { $0.data }, id: \.id) { reply in
-                    CommentView(comment: reply, nestLevel: self.nestLevel + 1)
+                    CommentView(comment: reply, postAuthor: self.postAuthor, nestLevel: self.nestLevel + 1)
                 }
             }
         }


### PR DESCRIPTION
Change the comment author color to the `accentColor` if the comment author is the same as the post author.

macOS:
<img width="1358" alt="macOS" src="https://user-images.githubusercontent.com/3119506/67151304-1c396980-f279-11e9-8703-6a832fc41942.png">

iOS:
<img width="389" height="698" alt="iOS" src="https://user-images.githubusercontent.com/3119506/67151302-1a6fa600-f279-11e9-90e2-15278e6245e0.png">
