### PR TITLE
Create previews for the Shared views

### DIFF
--- a/Shared/Models/Comment.swift
+++ b/Shared/Models/Comment.swift
@@ -46,7 +46,7 @@ extension Comment {
         id = "123"
         author = "sirarkimedes"
         score = 123556
-        body = "The Greatest Of All Time"
+        body = "This is a body of text that is purely to act as an example!"
         if nested != 0 {
             replies = CommentListing(data: CommentListing.CommentListingData(children: [CommentListing.CommentListingData.CommentData(data: Comment(nested: nested - 1))]))
         } else{

--- a/Shared/Models/Comment.swift
+++ b/Shared/Models/Comment.swift
@@ -38,3 +38,20 @@ struct Comment: Decodable {
         }
     }
 }
+
+#if DEBUG
+extension Comment {
+    /// Used to initialize a Comment for Debug purposes
+    init(nested: Int) {
+        id = "123"
+        author = "sirarkimedes"
+        score = 123556
+        body = "The Greatest Of All Time"
+        if nested != 0 {
+            replies = CommentListing(data: CommentListing.CommentListingData(children: [CommentListing.CommentListingData.CommentData(data: Comment(nested: nested - 1))]))
+        } else{
+            replies = nil
+        }
+    }
+}
+#endif

--- a/Shared/Models/Post.swift
+++ b/Shared/Models/Post.swift
@@ -63,3 +63,12 @@ struct Post: Decodable, Identifiable {
         }
     }
 }
+
+#if DEBUG
+extension Post {
+    /// Used to create a Post for example Debug purposes
+    static var example: Self {
+        return Post(title: "Hello World | This is secondary text", name: "hello-world", id: "hw", selftext: "This is some body content. Blah blah\nblah blah blah", selftext_html: nil, thumbnail: "blahblah", url: "", author: "me", subreddit: "swift", score: 1000, num_comments: 50, stickied: true, created_utc: Date().timeIntervalSince1970 - 100, preview: nil, link_flair_text: "Hello World", is_original_content: true, spoiler: false, replies: nil)
+    }
+}
+#endif

--- a/Shared/Views/CommentsView.swift
+++ b/Shared/Views/CommentsView.swift
@@ -9,6 +9,8 @@
 import SwiftUI
 import Request
 
+// MARK: - CommentsView
+
 struct CommentsView: View {
     let post: Post
     
@@ -39,6 +41,8 @@ struct CommentsView: View {
         }
     }
 }
+
+// MARK: - CommentView
 
 struct CommentView: View {
     let comment: Comment
@@ -85,3 +89,20 @@ struct CommentView: View {
         }
     }
 }
+
+// MARK: - Comment View preview
+
+#if DEBUG
+struct CommentView_Previews: PreviewProvider {
+    static func example(for author: String, nested: Int = 5) -> some View {
+        CommentView(comment: Comment(nested: nested), postAuthor: author, nestLevel: 0).frame(width: nil, height: 60)
+    }
+
+    static var previews: some View {
+        VStack {
+            example(for: "not", nested: 2)
+            example(for: "sirarkimedes")
+        }
+    }
+}
+#endif

--- a/Shared/Views/MetadataView.swift
+++ b/Shared/Views/MetadataView.swift
@@ -51,8 +51,7 @@ struct MetadataView: View {
 #if DEBUG
 struct MetadataView_Previews: PreviewProvider {
     static var previews: some View {
-        MetadataView(post: Post(title: "Hello World | This is secondary text", name: "hello-world", id: "hw", selftext: "This is some body content. Blah blah\nblah blah blah", selftext_html: nil, thumbnail: "blahblah", url: "", author: "me", subreddit: "swift", score: 1000, num_comments: 50, stickied: true, created_utc: Date().timeIntervalSince1970, preview: nil, link_flair_text: "Hello World", is_original_content: true, spoiler: false, replies: nil), spaced: true)
-        .font(.system(size: 10))
+        MetadataView(post: Post.example, spaced: true)
     }
 }
 #endif

--- a/Shared/Views/PostDetailView.swift
+++ b/Shared/Views/PostDetailView.swift
@@ -66,3 +66,11 @@ struct PostDetailView: View {
         #endif
     }
 }
+
+#if DEBUG
+struct PostDetailView_Previews: PreviewProvider {
+    static var previews: some View {
+        PostDetailView(post: Post.example)
+    }
+}
+#endif

--- a/Shared/Views/PostView.swift
+++ b/Shared/Views/PostView.swift
@@ -49,3 +49,11 @@ struct PostView: View {
         }
     }
 }
+
+#if DEBUG
+struct PostView_Previews: PreviewProvider {
+    static var previews: some View {
+        PostView(post: Post.example)
+    }
+}
+#endif


### PR DESCRIPTION
This creates some previews for the views that are inside of the Shared directory.
Additionally, I created a consolidated place to generate 'example' versions of some of the models that are used in these views. Feel free to suggest different ways to do this, if desired.

**PostView**:
<img width="408" alt="PostView" src="https://user-images.githubusercontent.com/3119506/67833466-f34b7c80-faa1-11e9-9ab0-0235148af172.png">

**PostDetailView**:
<img width="674" alt="PostDetailView" src="https://user-images.githubusercontent.com/3119506/67833473-f9415d80-faa1-11e9-9207-cbffed513351.png">

**CommentsView**:
<img width="674" alt="CommentsView" src="https://user-images.githubusercontent.com/3119506/67833477-fe9ea800-faa1-11e9-9e74-aeaf4d7559db.png">