### PR TITLE
Allows for single and double tap on each post

### DIFF
--- a/Reddit-macOS/ContentView.swift
+++ b/Reddit-macOS/ContentView.swift
@@ -22,8 +22,16 @@ struct ContentView : View {
     var body: some View {
         NavigationView {
             /// Load the posts
-            PostList(subreddit: state.subreddit, sortBy: state.sortBy)
-                .frame(minWidth: 300)
+            RequestView(Listing.self, Request {
+                Url(API.subredditURL(state.subreddit, sortBy))
+                Query(["raw_json":"1"])
+            }) { listing in
+                PostList(listing: listing, subreddit: self.state.subreddit, sortBy: self.state.sortBy)
+                    .frame(minWidth: 300)
+                /// Spinner when loading
+                SpinnerView()
+                    .frame(minWidth: 300, minHeight: 300)
+            }
             Text("Select a post")
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         }

--- a/Reddit-macOS/ContentView.swift
+++ b/Reddit-macOS/ContentView.swift
@@ -15,7 +15,7 @@ struct ContentView : View {
     @State private var showSortSheet: Bool = false
     @State private var showSubredditSheet: Bool = false
     
-    @State private var selectedPost: String? = nil
+    @State private var selectedPostId: String? = nil
     
     @EnvironmentObject private var state: ContentViewState
     
@@ -26,8 +26,13 @@ struct ContentView : View {
                 Url(API.subredditURL(state.subreddit, sortBy))
                 Query(["raw_json":"1"])
             }) { listing in
-                PostList(listing: listing, subreddit: self.state.subreddit, sortBy: self.state.sortBy)
+                if listing != nil {
+                    PostList(posts: listing!.posts, subreddit: self.state.subreddit, sortBy: self.state.sortBy, selectedPostId: self.$selectedPostId)
                     .frame(minWidth: 300)
+                }
+                else {
+                    Text("Error while loading posts").frame(minWidth: 300, minHeight: 300)
+                }
                 /// Spinner when loading
                 SpinnerView()
                     .frame(minWidth: 300, minHeight: 300)

--- a/Reddit-macOS/Views/PostList.swift
+++ b/Reddit-macOS/Views/PostList.swift
@@ -48,14 +48,12 @@ struct PostList: View {
             Section(header: Text("\(subreddit) | \(sortBy.rawValue)")) {
                 /// List of `PostView`s when loaded
                 ForEach(posts) { post in
-                    VStack {
-                        NavigationLink(destination: PostDetailView(post: post), tag: post.id, selection: self.selectedNavigationLink) { EmptyView() }
+                    NavigationLink(destination: PostDetailView(post: post), tag: post.id, selection: self.selectedNavigationLink) {
                         PostView(post: post)
                     }
                     .tag(post.id)
                     .padding(EdgeInsets(top: 5, leading: 0, bottom: 5, trailing: 0))
                     .contentShape(Rectangle())
-
                         /// Double-click to open a new window for the `PostDetailView`
                         .onTapGesture(count: 2) {
                             let detailView = PostDetailView(post: post)
@@ -70,6 +68,7 @@ struct PostList: View {
                     }
                 }
             }
+            .collapsible(false)
         }
         .listStyle(SidebarListStyle())
     }

--- a/Reddit-macOS/Views/PostList.swift
+++ b/Reddit-macOS/Views/PostList.swift
@@ -10,39 +10,64 @@ import SwiftUI
 import Request
 
 struct PostList: View {
-    let listing: Listing?
+    let posts: [Post]
     let subreddit: String
     let sortBy: SortBy
-    
-    @State private var selection: String? = nil
-    @State private var selectedPostIds: Set<String> = Set()
+
+    @Binding var selectedPostId: String?
+
+    private var selectedPostIds: Binding<Set<String>> {
+        Binding(
+            get: {
+                if let selectedPostId = self.selectedPostId {
+                    return Set(arrayLiteral: selectedPostId)
+                }
+                else {
+                    return Set()
+                }
+        },
+            set: {
+                self.selectedPostId = $0.first
+        }
+        )
+    }
+
+    private var selectedNavigationLink: Binding<String?> {
+        Binding<String?>(
+            get: {
+                return self.selectedPostId
+        },
+            set: { selectedPostId in
+                // Absorbing any change that NavigationLink does to its selection property
+        }
+        )
+    }
     
     var body: some View {
-        List(selection: $selectedPostIds) {
+        List(selection: selectedPostIds) {
             Section(header: Text("\(subreddit) | \(sortBy.rawValue)")) {
                 /// List of `PostView`s when loaded
-                ForEach(listing != nil ? listing!.data.children.map { $0.data } : []) { post in
+                ForEach(posts) { post in
                     VStack {
-                        NavigationLink(destination: PostDetailView(post: post), tag: post.id, selection: self.$selection) { EmptyView() }
+                        NavigationLink(destination: PostDetailView(post: post), tag: post.id, selection: self.selectedNavigationLink) { EmptyView() }
                         PostView(post: post)
-                            .tag(post.id)
-                            .padding(EdgeInsets(top: 5, leading: 0, bottom: 5, trailing: 0))
-                            .contentShape(Rectangle())
-                            /// Double-click to open a new window for the `PostDetailView`
-                            .onTapGesture(count: 2) {
-                                let detailView = PostDetailView(post: post)
-                                
-                                let controller = DetailWindowController(rootView: detailView)
-                                controller.window?.title = post.title
-                                controller.showWindow(nil)
-                        }
-                            /// Adding after the double tap so that double tap takes precedence
-                        .onTapGesture(count: 1) {
-                            self.selection = post.id
-                            self.selectedPostIds = Set(arrayLiteral: post.id)
-                        }
                     }
                     .tag(post.id)
+                    .padding(EdgeInsets(top: 5, leading: 0, bottom: 5, trailing: 0))
+                    .contentShape(Rectangle())
+
+                        /// Double-click to open a new window for the `PostDetailView`
+                        .onTapGesture(count: 2) {
+                            let detailView = PostDetailView(post: post)
+
+                            let controller = DetailWindowController(rootView: detailView)
+                            controller.window?.title = post.title
+                            controller.showWindow(nil)
+                    }
+                        /// Adding after the double tap so that double tap takes precedence
+                        .onTapGesture(count: 1) {
+                            self.selectedPostId = post.id
+                    }
                 }
             }
         }

--- a/Reddit-macOS/Views/PostList.swift
+++ b/Reddit-macOS/Views/PostList.swift
@@ -15,9 +15,10 @@ struct PostList: View {
     let sortBy: SortBy
     
     @State private var selection: String? = nil
+    @State private var selectedPostIds: Set<String> = Set()
     
     var body: some View {
-        List {
+        List(selection: $selectedPostIds) {
             Section(header: Text("\(subreddit) | \(sortBy.rawValue)")) {
                 /// List of `PostView`s when loaded
                 ForEach(listing != nil ? listing!.data.children.map { $0.data } : []) { post in
@@ -38,8 +39,10 @@ struct PostList: View {
                             /// Adding after the double tap so that double tap takes precedence
                         .onTapGesture(count: 1) {
                             self.selection = post.id
+                            self.selectedPostIds = Set(arrayLiteral: post.id)
                         }
                     }
+                    .tag(post.id)
                 }
             }
         }

--- a/Shared/Models/Listing.swift
+++ b/Shared/Models/Listing.swift
@@ -11,6 +11,11 @@ import Foundation
 /// Root of Reddit API response
 struct Listing: Decodable {
     let data: ListingData
+    var posts: [Post] {
+        return data.children.map { (postData) -> Post in
+            postData.data
+        }
+    }
     
     struct ListingData: Decodable {
         let children: [PostData]


### PR DESCRIPTION
Fixes https://github.com/carson-katri/reddit-swiftui/issues/9

Quite a lot of changes in order to achieve this:
- had to activate the navigation link programmatically in order to capture single and double tap
- NavigationLink activated based on new view state for selected post tag
- moved the RequestView to the ContentView so the selected post wouldn't reload the whole PostList and repeat the request
- PostList now initialised with Listing object
- setting the contentShape of the PostView in the list in order to capture hits in the whole area, otherwise it would land on the NavigationLink behind
- adding two tap gestures in order of precedence
- set the default frame for the new spinner to guarantee a minimum size while loading

The only secondary effect from this solution I wasn't able to fix is that now cells don't get a selected state like before. Hopefully someone knows how to fix that, otherwise can be a good bug to follow up with.