### PR TITLE
Added a spacer to PostView to align thumbnails to the right

### DIFF
--- a/Shared/Views/PostView.swift
+++ b/Shared/Views/PostView.swift
@@ -13,7 +13,7 @@ struct PostView: View {
     let post: Post
     
     var body: some View {
-        HStack(spacing: 5) {
+        HStack {
             VStack(alignment: .leading) {
                 #if os(iOS)
                 Text(post.title)
@@ -40,6 +40,7 @@ struct PostView: View {
                     .opacity(0.75)
             }
             if post.thumbnail != "self" {
+                Spacer()
                 RequestImage(Url(post.thumbnail))
                     .aspectRatio(contentMode: .fill)
                     .frame(width: 50, height: 50, alignment: .center)


### PR DESCRIPTION
Some thumbnails were not aligned horizontally.
So while playing with SwiftUI I got to fix another annoyance